### PR TITLE
Fix invalid argument exception in media list view

### DIFF
--- a/src/FocalPointPicker.php
+++ b/src/FocalPointPicker.php
@@ -136,6 +136,9 @@ class FocalPointPicker
         array $atts,
         WP_Post $attachment
     ): array {
+        if (!wp_attachment_is_image($attachment)) {
+            return $atts;
+        }
         $focalPoint = new FocalPoint($attachment);
 
         $atts['class'] ??= '';


### PR DESCRIPTION
Fixes #10 

Don't assume `$attachment` is an image in `wp_get_attachment_image_attributes`

I don't understand why `wp_get_attachment_image_attributes` would ever receive a non-image as an argument... it might be related to WordPress rendering an SVG icon for images in the admin.

![CleanShot 2025-02-11 at 14 24 38@2x](https://github.com/user-attachments/assets/0aa30cd8-fd26-4803-87e7-528d9308dea1)